### PR TITLE
Fixed max height bug

### DIFF
--- a/src/useIonicHeaderParallax.ts
+++ b/src/useIonicHeaderParallax.ts
@@ -147,7 +147,7 @@ export function useIonHeaderParallax({
       // .scroll-content
       if (scrollContent) {
         scrollContent.setAttribute('parallax', '')
-        scrollContent.style.paddingTop = `250px`
+        scrollContent.style.paddingTop = `${maximumHeight}px`
       }
 
       if (scrollContent) {


### PR DESCRIPTION
First of all, thank you very much for this contribution to Ionic React. ❤️ ⚛️ 

When we add a maximum height, the paddingTop does not adapt dynamically. This change is tested in Ionic 6.0.4 version.


**Bug example:**

https://user-images.githubusercontent.com/26112509/151979079-e1abcb97-82d0-48bc-a4e2-a0c1761f061a.mov


**Example with dynamic paddingTop:**

https://user-images.githubusercontent.com/26112509/151979351-50d193b2-1837-4ee3-967c-5b88354bfa5b.mov


